### PR TITLE
libarchive-dev installs libarchive as a dependency.

### DIFF
--- a/providers/file.rb
+++ b/providers/file.rb
@@ -12,10 +12,6 @@ action :extract do
     raise Errno::ENOENT, "no archive found at #{new_resource.path}"
   end
 
-  package "libarchive12" do
-    action :nothing
-  end.run_action(:install)
-
   package "libarchive-dev" do
     action :nothing
   end.run_action(:install)


### PR DESCRIPTION
Ubuntu requires different versions of the libarchive runtime. libarchive-dev always installs the appropriate libarchive as a dependency for every version of Ubuntu.

Fixes #1.
