### PR TITLE
Remove broken support for CentOS 5

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,7 +10,6 @@ platforms:
   - name: ubuntu-12.04
   - name: centos-7.1
   - name: centos-6.6
-  - name: centos-5.11
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,4 +13,3 @@ supports "arch"
 supports "mac_os_x"
 
 depends "apt", ">= 2.5"
-depends "yum-epel", "~> 0.6"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,9 +6,6 @@
 #
 
 include_recipe 'apt::default' if platform_family?('debian')
-if platform_family?('redhat')
-  include_recipe 'yum-epel::default' if node[:platform_version].to_i == 5
-end
 
 package node[:libarchive][:package_name] do
   version node[:libarchive][:package_version] if node[:libarchive][:package_version]


### PR DESCRIPTION
This never worked because `platform_family?` should have checked for `rhel` and not `redhat`. That aside, it cannot work via the yum-epel cookbook anyway because the EPEL repository is needed at compile time.

This isn't the end of the world as CentOS 5 maintenance ends soon.

Note that my primary motivation here is to remove the constraint on the yum-epel cookbook as that is holding other cookbooks back.