### PR TITLE
Modernize cookbook to allow for testing on debian style systems.

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,0 +1,1 @@
+remote_file = "https://raw.githubusercontent.com/chef-cookbooks/community_cookbook_tools/master/delivery/project.toml"

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+### Cookbook version
+[Version of the cookbook where you are encountering the issue]
+
+### Chef-client version
+[Version of chef-client in your environment]
+
+### Platform Details
+[Operating system distribution and release version. Cloud provider if running in the cloud]
+
+### Scenario:
+[What you are trying to achieve and you can't?]
+
+### Steps to Reproduce:
+[If you are filing an issue what are the things we need to do in order to repro your problem? How are you using this cookbook or any resources it includes?]
+
+### Expected Result:
+[What are you expecting to happen as the consequence of above reproduction steps?]
+
+### Actual Result:
+[What actually happens after the reproduction steps? Include the error output or a link to a gist if possible.]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+### Description
+
+[Describe what this change achieves]
+
+### Issues Resolved
+
+[List any existing issues this PR resolves]
+
+### Check List
+
+- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
+- [ ] New functionality includes testing.
+- [ ] New functionality has been documented in the README if applicable
+- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,0 +1,54 @@
+driver:
+  name: dokken
+  privileged: true # because Docker and SystemD/Upstart
+  chef_version: current
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+  deprecations_as_errors: true
+
+verifier:
+  name: inspec
+
+platforms:
+- name: centos-6
+  driver:
+    image: centos:6
+    platform: rhel
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN yum -y install lsof which initscripts net-tools wget net-tools
+
+- name: centos-7
+  driver:
+    image: centos:7
+    platform: rhel
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+      - RUN yum -y install lsof which systemd-sysv initscripts wget net-tools
+
+- name: fedora-latest
+  driver:
+    image: fedora:latest
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+      - RUN dnf -y install which systemd-sysv initscripts wget net-tools
+
+- name: ubuntu-14.04
+  driver:
+    image: ubuntu-upstart:14.04
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+
+- name: ubuntu-16.04
+  driver:
+    image: ubuntu:16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,14 +4,15 @@ driver:
 
 provisioner:
   name: chef_zero
+  deprecations_as_errors: true
 
 platforms:
   - name: ubuntu-14.04
-  - name: ubuntu-12.04
-  - name: centos-7.1
-  - name: centos-6.6
+  - name: ubuntu-16.04
+  - name: centos-6.8
+  - name: centos-7.3
 
 suites:
   - name: default
     run_list:
-      - recipe[test-libarchive::default]
+      - recipe[test]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+sudo: required
+dist: trusty
+
+addons:
+  apt:
+    sources:
+      - chef-stable-trusty
+    packages:
+      - chefdk
+
+install: echo "skip bundle install"
+
+branches:
+  only:
+    - master
+
+services: docker
+
+env:
+  matrix:
+  - INSTANCE=default-centos-6
+  - INSTANCE=default-centos-7
+  - INSTANCE=default-ubuntu-1404
+  - INSTANCE=default-ubuntu-1604
+
+before_script:
+  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
+  - /opt/chefdk/embedded/bin/chef --version
+  - /opt/chefdk/embedded/bin/cookstyle --version
+  - /opt/chefdk/embedded/bin/foodcritic --version
+
+script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}
+
+matrix:
+  include:
+    - script:
+      - /opt/chefdk/bin/chef exec delivery local all
+      env: UNIT_AND_LINT=1

--- a/Berksfile
+++ b/Berksfile
@@ -2,5 +2,5 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :test, :integration do
-  cookbook 'test-libarchive', path: File.expand_path('../test/fixtures/cookbooks/test', __FILE__)
+  cookbook 'test', path: 'test/fixtures/cookbooks/test'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file is used to list changes made in each version of the libarchive cookbook.
 
+## (UNRELEASED)
+
+- Update license string to standard Apache-2.0
+- Update maintainer information 
+- Add source_url and issue_url 
+- Add apt-update for debian platforms in test cookbook
+- Remove EOL platforms from .kitchen.yml
+- Add ubuntu-16.04, update latest centos 6, 7 platforms in .kitchen.yml
+- Modify test suite to use test cookbook
+
 ## 0.7.0 (2017-03-15)
 
 - Remove broken support for CentOS 5 and the yum-epel cookbook dependency

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+Please refer to
+https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

--- a/README.md
+++ b/README.md
@@ -56,3 +56,17 @@ Include this recipe before leveraging any of the LWRPs provided by this cookbook
 
 Author:: Jamie Winsor (<jamie@vialstudios.com>)
 Author:: John Bellone (<jbellone@bloomberg.net>)
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,2 @@
+Please refer to
+https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name             'libarchive'
-maintainer       'Jamie Winsor'
-maintainer_email 'jamie@vialstudios.com'
-license          'Apache 2.0'
+maintainer 'Chef Software, Inc.'
+maintainer_email 'cookbooks@chef.io'
+license 'Apache-2.0'
 description      'A library cookbook for extracting archive files'
 long_description 'A library cookbook for extracting archive files'
 version          '0.7.0'
@@ -11,3 +11,7 @@ supports 'centos'
 supports 'redhat'
 supports 'arch'
 supports 'mac_os_x'
+
+source_url 'https://github.com/chef-cookbooks/libarchive'
+issues_url 'https://github.com/chef-cookbooks/libarchive/issues'
+chef_version '>= 12.7' if respond_to?(:chef_version)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,8 +5,8 @@
 # Author:: Jamie Winsor (<jamie@vialstudios.com>)
 #
 
-package node[:libarchive][:package_name] do
-  version node[:libarchive][:package_version] if node[:libarchive][:package_version]
+package node['libarchive']['package_name'] do
+  version node['libarchive']['package_version'] if node['libarchive']['package_version']
   action :nothing
 end.run_action(:upgrade)
 

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -1,3 +1,3 @@
-name 'test-libarchive'
+name 'test'
 version '0.0.1'
 depends 'libarchive'

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,3 +1,6 @@
+apt_update 'update' do
+end.run_action(:update) if platform_family?('debian')
+
 include_recipe 'libarchive::default'
 
 zipball = remote_file 'twbs-v3.3.4.zip' do


### PR DESCRIPTION
- Update license string to standard Apache-2.0
- Update maintainer information
- Add source_url and issue_url
- Add apt-update for debian platforms in test cookbook
- Remove EOL platforms from .kitchen.yml
- Add ubuntu-16.04, update latest centos 6, 7 platforms in .kitchen.yml
- Modify test suite to use test cookbook
Signed-off-by: Jennifer Davis <iennae@gmail.com>