### PR TITLE
Add support for NO_OVERWRITE_NEWER

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -19,6 +19,7 @@ module LibArchiveCookbook
           fflags: Archive::EXTRACT_FFLAGS,
           extended_information: Archive::EXTRACT_XATTR,
           xattr: Archive::EXTRACT_XATTR,
+          no_overwrite_newer: Archive::EXTRACT_NO_OVERWRITE_NEWER,
         }
       end
 


### PR DESCRIPTION
Signed-off-by: Joshua Justice <jjustice6@bloomberg.net>

### Description

Add support for Archive::EXTRACT_NO_OVERWRITE_NEWER, as defined in https://github.com/chef/ffi-libarchive/blob/6cb045fae9547c0d1c3eb93f4431faa8349446ad/lib/ffi-libarchive/archive.rb#L265

### Issues Resolved

Allows for use of the EXTRACT_NO_OVERWRITE_NEWER option.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
