### PR TITLE
Does not work on windows, removed from supports

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'A library cookbook for extracting archive files'
 long_description 'A library cookbook for extracting archive files'
 version          '2.1.0'
 
-%w(windows ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon).each do |os|
+%w(ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon).each do |os|
   supports os
 end
 


### PR DESCRIPTION
Signed-off-by: Stefan Wessels Beljaars <swesselsbeljaars@schubergphilis.com>

### Description

Updated `metadata.rb` to remove windows support, because it does not work on windows

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
